### PR TITLE
more convenient way of opening a file manager

### DIFF
--- a/arch-deployer
+++ b/arch-deployer
@@ -104,7 +104,7 @@ echo "
 ############################################################################
 "
 sleep 2
-exo-open --launch FileManager ./$APP/$APP.AppDir
+xdg-open ./$APP/$APP.AppDir
 
 echo ""
 


### PR DESCRIPTION
exo-open is available in some DE/WM whereas xdg-open is available for all WM/DE by default which opens files in a default file manager